### PR TITLE
Make `length` function to consider surrogate-pairs

### DIFF
--- a/eastasianwidth.js
+++ b/eastasianwidth.js
@@ -268,10 +268,16 @@ eaw.characterLength = function(character) {
   }
 };
 
+// Split a string considering surrogate-pairs.
+function stringToArray(string) {
+  return string.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\uD800-\uDFFF]/g) || [];
+}
+
 eaw.length = function(string) {
+  var characters = stringToArray(string);
   var len = 0;
-  for (var i = 0; i < string.length; i++) {
-    len = len + this.characterLength(string.charAt(i));
+  for (var i = 0; i < characters.length; i++) {
+    len = len + this.characterLength(characters[i]);
   }
   return len;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,7 @@ describe('characterLength', function() {
   it('Fullwidth', function() {
     assert.equal(2, eaw.characterLength('￠'));
     assert.equal(2, eaw.characterLength('￦'));
+    assert.equal(2, eaw.characterLength('𩸽'));
   });
 
   it('Halfwidth', function() {
@@ -79,5 +80,9 @@ describe('length', function() {
 
   it('Mixed', function() {
     assert.equal(19, eaw.length('￠￦｡ￜㄅ뀀¢⟭a⊙①بف'));
+  });
+
+  it('Surrogate-Pair character included', function() {
+    assert.equal(4, eaw.length('a𩸽b'));
   });
 });


### PR DESCRIPTION
Hello.

JavaScript has some problems with surrogate-pairs.
Ref) https://qiita.com/YusukeHirao/items/2f0fb8d5bbb981101be0

One of the problems is to interpret the characters of the surrogate-pair as two letters.
For example, the following for statement loops twice.

```js
var str = '𩸽';
for (var i = 0; i < str.length; i++) {
  console.log(str[i]);  // Output 2 times with "\uD867" and "\uDE3D"
}
```

Therefore, I was concerned whether this part is working properly.

https://github.com/komagata/eastasianwidth/blob/5fc94f78afff2c2c123a2f3be7e4e4318948ff21/eastasianwidth.js#L274

However, in conclusion, **there was no problem as a result**.

All the surrogate pair character width may be interpreted as probably two characters, then the current logic is correct.

----

But, I think that strings should be looped with the following functions inherently.

```js
function stringToArray (string) {
  return string.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\uD800-\uDFFF]/g) || [];
}
```

~~It will be submitted as a different pull request.~~
Sorry, I decided to include it in this.
This test was necessary for the implementation.

Thanks.