### PR TITLE
Make slice method more consistent on full/half width mixed texts

### DIFF
--- a/eastasianwidth.js
+++ b/eastasianwidth.js
@@ -283,15 +283,28 @@ eaw.length = function(string) {
 };
 
 eaw.slice = function(text, start, end) {
+  textLen = eaw.length(text)
   start = start ? start : 0;
   end = end ? end : 1;
+  if (start < 0) {
+      start = textLen + start;
+  }
+  if (end < 0) {
+      end = textLen + end;
+  }
   var result = '';
+  var eawLen = 0;
   for (var i = 0; i < text.length; i++) {
     var char = text.charAt(i);
-    var eawLen = eaw.length(result + char);
-    if (eawLen >= 1 + start && eawLen < 1 + end) {
-      result += char
+    var charLen = eaw.length(char);
+    if (eawLen >= start - (charLen == 2 ? 1 : 0)) {
+        if (eawLen + charLen <= end) {
+            result += char;
+        } else {
+            break;
+        }
     }
+    eawLen += charLen;
   }
   return result;
 };

--- a/eastasianwidth.js
+++ b/eastasianwidth.js
@@ -294,8 +294,9 @@ eaw.slice = function(text, start, end) {
   }
   var result = '';
   var eawLen = 0;
-  for (var i = 0; i < text.length; i++) {
-    var char = text.charAt(i);
+  var chars = stringToArray(text);
+  for (var i = 0; i < chars.length; i++) {
+    var char = chars[i];
     var charLen = eaw.length(char);
     if (eawLen >= start - (charLen == 2 ? 1 : 0)) {
         if (eawLen + charLen <= end) {

--- a/test/test.js
+++ b/test/test.js
@@ -86,3 +86,38 @@ describe('length', function() {
     assert.equal(4, eaw.length('a𩸽b'));
   });
 });
+
+
+describe('slice', function() {
+  it('Fullwidth', function() {
+    assert.equal(eaw.slice('あいうえお', 0, 6), 'あいう');
+    assert.equal(eaw.slice('あいうえお', 2, 8), 'いうえ');
+    assert.equal(eaw.slice('あいうえお', 4, 10), 'うえお');
+    assert.equal(eaw.slice('あいうえお', 2, -2), 'いうえ');
+    assert.equal(eaw.slice('あいうえお', -2, 10), 'お');
+  });
+  it('Fullwidth, start / end is not aligned', function() {
+    assert.equal(eaw.slice('あいうえお', 0, 1), '');
+    assert.equal(eaw.slice('あいうえお', 1, 9), 'あいうえ');
+    assert.equal(eaw.slice('あいうえお', 9, 10), 'お');
+    assert.equal(eaw.slice('あいうえお', -1, 10), 'お');
+    assert.equal(eaw.slice('あいうえお', 1, -1), 'あいうえ');
+  });
+  it('Halfwidth', function() {
+    assert.equal(eaw.slice('abcdefg', 0, 3), 'abc');
+    assert.equal(eaw.slice('abcdefg', 3, 6), 'def');
+    assert.equal(eaw.slice('abcdefg', -2, 7), 'fg');
+    assert.equal(eaw.slice('abcdefg', 5, -1), 'f');
+  });
+  it('Mixed', function() {
+    assert.equal(eaw.slice('aあb', 0, 3), 'aあ');
+    assert.equal(eaw.slice('aあb', 1, 4), 'あb');
+  });
+  it('Mixed, start / end is not aligned', function() {
+    assert.equal(eaw.slice('aあb', 0, 2), 'a');
+    assert.equal(eaw.slice('aあb', 2, 4), 'あb');
+    assert.equal(eaw.slice('aあb', -2, 4), 'あb');
+    assert.equal(eaw.slice('aあb', 2, -1), 'あ');
+    assert.equal(eaw.slice('aあb', 0, 2) + eaw.slice('aあb', 2, 4), 'aあb');
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -120,4 +120,12 @@ describe('slice', function() {
     assert.equal(eaw.slice('aあb', 2, -1), 'あ');
     assert.equal(eaw.slice('aあb', 0, 2) + eaw.slice('aあb', 2, 4), 'aあb');
   });
+  it('Surrogate-Pair character included', function() {
+    assert.equal(eaw.slice('a𩸽b', 0, 3), 'a𩸽');
+    assert.equal(eaw.slice('a𩸽b', 1, 4), '𩸽b');
+  });
+  it('Surrogate-Pair character included, start / end is not aligned', function() {
+    assert.equal(eaw.slice('a𩸽b', 0, 2), 'a');
+    assert.equal(eaw.slice('a𩸽b', 2, 4), '𩸽b');
+  });
 });


### PR DESCRIPTION
This pull request fixes inconsistent behavior of slice method introduced on #1 

The original slice method works well on half-width only or full-width only texts. But in the case full/half width mixed text with not aligned start / end arguments, it does (surprising) inconsistent behavior.

```javascript
>> eastasianwidth.slice('aあb', 0, 2);
'ab'  // Wrong. It should be 'a' or 'aあ'
```

This result comes from following logic of original slice method:
https://github.com/komagata/eastasianwidth/pull/1/files#diff-ffd3dfba0241e93f4dcb5fb1e3d1811dR286

During scanning text from begin to end, it checks current length of `result` variable and the next character. Each characters are appended to the end of `result` variable if condition of above passed.

Unfortunately, the original slice method does not consider full and half width character mixed text. It may skips intermediate full-width character and then concatenate later half-width character as example described above.

I added some tests to check whole consistency of slice method as well as I fixed this inconsistent behavior. In the case start / end arguments are not aligned to full-width characters, slice method behave as backward compatible as it can (see tests).

Additionally I added a capability to passing negative value to slice method's start / end arguments as String.slice on JavaScript core can.