### PR TITLE
Fix 3 things

### DIFF
--- a/eastasianwidth.js
+++ b/eastasianwidth.js
@@ -283,7 +283,7 @@ eaw.length = function(string) {
 };
 
 eaw.slice = function(text, start, end) {
-  textLen = eaw.length(text)
+  var textLen = eaw.length(text)
   start = start ? start : 0;
   end = end ? end : 1;
   if (start < 0) {

--- a/eastasianwidth.js
+++ b/eastasianwidth.js
@@ -284,8 +284,8 @@ eaw.length = function(string) {
 
 eaw.slice = function(text, start, end) {
   var textLen = eaw.length(text)
-  start = start ? start : 0;
-  end = end ? end : 1;
+  start = start === undefined || start === null ? 0 : start;
+  end = end === undefined || start === null ? 1 : end;
   if (start < 0) {
       start = textLen + start;
   }

--- a/eastasianwidth.js
+++ b/eastasianwidth.js
@@ -1,6 +1,6 @@
 var eaw = {};
 
-if ('undefined' == typeof module) {
+if ('undefined' === typeof module) {
   window.eastasianwidth = eaw;
 } else {
   module.exports = eaw;
@@ -8,7 +8,7 @@ if ('undefined' == typeof module) {
 
 eaw.eastAsianWidth = function(character) {
   var x = character.charCodeAt(0);
-  var y = (character.length == 2) ? character.charCodeAt(1) : 0;
+  var y = (character.length === 2) ? character.charCodeAt(1) : 0;
   var codePoint = x;
   if ((0xD800 <= x && x <= 0xDBFF) && (0xDC00 <= y && y <= 0xDFFF)) {
     x &= 0x3FF;
@@ -17,12 +17,12 @@ eaw.eastAsianWidth = function(character) {
     codePoint += 0x10000;
   }
 
-  if ((0x3000 == codePoint) ||
+  if ((0x3000 === codePoint) ||
       (0xFF01 <= codePoint && codePoint <= 0xFF60) ||
       (0xFFE0 <= codePoint && codePoint <= 0xFFE6)) {
     return 'F';
   }
-  if ((0x20A9 == codePoint) ||
+  if ((0x20A9 === codePoint) ||
       (0xFF61 <= codePoint && codePoint <= 0xFFBE) ||
       (0xFFC2 <= codePoint && codePoint <= 0xFFC7) ||
       (0xFFCA <= codePoint && codePoint <= 0xFFCF) ||
@@ -74,135 +74,135 @@ eaw.eastAsianWidth = function(character) {
   if ((0x0020 <= codePoint && codePoint <= 0x007E) ||
       (0x00A2 <= codePoint && codePoint <= 0x00A3) ||
       (0x00A5 <= codePoint && codePoint <= 0x00A6) ||
-      (0x00AC == codePoint) ||
-      (0x00AF == codePoint) ||
+      (0x00AC === codePoint) ||
+      (0x00AF === codePoint) ||
       (0x27E6 <= codePoint && codePoint <= 0x27ED) ||
       (0x2985 <= codePoint && codePoint <= 0x2986)) {
     return 'Na';
   }
-  if ((0x00A1 == codePoint) ||
-      (0x00A4 == codePoint) ||
+  if ((0x00A1 === codePoint) ||
+      (0x00A4 === codePoint) ||
       (0x00A7 <= codePoint && codePoint <= 0x00A8) ||
-      (0x00AA == codePoint) ||
+      (0x00AA === codePoint) ||
       (0x00AD <= codePoint && codePoint <= 0x00AE) ||
       (0x00B0 <= codePoint && codePoint <= 0x00B4) ||
       (0x00B6 <= codePoint && codePoint <= 0x00BA) ||
       (0x00BC <= codePoint && codePoint <= 0x00BF) ||
-      (0x00C6 == codePoint) ||
-      (0x00D0 == codePoint) ||
+      (0x00C6 === codePoint) ||
+      (0x00D0 === codePoint) ||
       (0x00D7 <= codePoint && codePoint <= 0x00D8) ||
       (0x00DE <= codePoint && codePoint <= 0x00E1) ||
-      (0x00E6 == codePoint) ||
+      (0x00E6 === codePoint) ||
       (0x00E8 <= codePoint && codePoint <= 0x00EA) ||
       (0x00EC <= codePoint && codePoint <= 0x00ED) ||
-      (0x00F0 == codePoint) ||
+      (0x00F0 === codePoint) ||
       (0x00F2 <= codePoint && codePoint <= 0x00F3) ||
       (0x00F7 <= codePoint && codePoint <= 0x00FA) ||
-      (0x00FC == codePoint) ||
-      (0x00FE == codePoint) ||
-      (0x0101 == codePoint) ||
-      (0x0111 == codePoint) ||
-      (0x0113 == codePoint) ||
-      (0x011B == codePoint) ||
+      (0x00FC === codePoint) ||
+      (0x00FE === codePoint) ||
+      (0x0101 === codePoint) ||
+      (0x0111 === codePoint) ||
+      (0x0113 === codePoint) ||
+      (0x011B === codePoint) ||
       (0x0126 <= codePoint && codePoint <= 0x0127) ||
-      (0x012B == codePoint) ||
+      (0x012B === codePoint) ||
       (0x0131 <= codePoint && codePoint <= 0x0133) ||
-      (0x0138 == codePoint) ||
+      (0x0138 === codePoint) ||
       (0x013F <= codePoint && codePoint <= 0x0142) ||
-      (0x0144 == codePoint) ||
+      (0x0144 === codePoint) ||
       (0x0148 <= codePoint && codePoint <= 0x014B) ||
-      (0x014D == codePoint) ||
+      (0x014D === codePoint) ||
       (0x0152 <= codePoint && codePoint <= 0x0153) ||
       (0x0166 <= codePoint && codePoint <= 0x0167) ||
-      (0x016B == codePoint) ||
-      (0x01CE == codePoint) ||
-      (0x01D0 == codePoint) ||
-      (0x01D2 == codePoint) ||
-      (0x01D4 == codePoint) ||
-      (0x01D6 == codePoint) ||
-      (0x01D8 == codePoint) ||
-      (0x01DA == codePoint) ||
-      (0x01DC == codePoint) ||
-      (0x0251 == codePoint) ||
-      (0x0261 == codePoint) ||
-      (0x02C4 == codePoint) ||
-      (0x02C7 == codePoint) ||
+      (0x016B === codePoint) ||
+      (0x01CE === codePoint) ||
+      (0x01D0 === codePoint) ||
+      (0x01D2 === codePoint) ||
+      (0x01D4 === codePoint) ||
+      (0x01D6 === codePoint) ||
+      (0x01D8 === codePoint) ||
+      (0x01DA === codePoint) ||
+      (0x01DC === codePoint) ||
+      (0x0251 === codePoint) ||
+      (0x0261 === codePoint) ||
+      (0x02C4 === codePoint) ||
+      (0x02C7 === codePoint) ||
       (0x02C9 <= codePoint && codePoint <= 0x02CB) ||
-      (0x02CD == codePoint) ||
-      (0x02D0 == codePoint) ||
+      (0x02CD === codePoint) ||
+      (0x02D0 === codePoint) ||
       (0x02D8 <= codePoint && codePoint <= 0x02DB) ||
-      (0x02DD == codePoint) ||
-      (0x02DF == codePoint) ||
+      (0x02DD === codePoint) ||
+      (0x02DF === codePoint) ||
       (0x0300 <= codePoint && codePoint <= 0x036F) ||
       (0x0391 <= codePoint && codePoint <= 0x03A1) ||
       (0x03A3 <= codePoint && codePoint <= 0x03A9) ||
       (0x03B1 <= codePoint && codePoint <= 0x03C1) ||
       (0x03C3 <= codePoint && codePoint <= 0x03C9) ||
-      (0x0401 == codePoint) ||
+      (0x0401 === codePoint) ||
       (0x0410 <= codePoint && codePoint <= 0x044F) ||
-      (0x0451 == codePoint) ||
-      (0x2010 == codePoint) ||
+      (0x0451 === codePoint) ||
+      (0x2010 === codePoint) ||
       (0x2013 <= codePoint && codePoint <= 0x2016) ||
       (0x2018 <= codePoint && codePoint <= 0x2019) ||
       (0x201C <= codePoint && codePoint <= 0x201D) ||
       (0x2020 <= codePoint && codePoint <= 0x2022) ||
       (0x2024 <= codePoint && codePoint <= 0x2027) ||
-      (0x2030 == codePoint) ||
+      (0x2030 === codePoint) ||
       (0x2032 <= codePoint && codePoint <= 0x2033) ||
-      (0x2035 == codePoint) ||
-      (0x203B == codePoint) ||
-      (0x203E == codePoint) ||
-      (0x2074 == codePoint) ||
-      (0x207F == codePoint) ||
+      (0x2035 === codePoint) ||
+      (0x203B === codePoint) ||
+      (0x203E === codePoint) ||
+      (0x2074 === codePoint) ||
+      (0x207F === codePoint) ||
       (0x2081 <= codePoint && codePoint <= 0x2084) ||
-      (0x20AC == codePoint) ||
-      (0x2103 == codePoint) ||
-      (0x2105 == codePoint) ||
-      (0x2109 == codePoint) ||
-      (0x2113 == codePoint) ||
-      (0x2116 == codePoint) ||
+      (0x20AC === codePoint) ||
+      (0x2103 === codePoint) ||
+      (0x2105 === codePoint) ||
+      (0x2109 === codePoint) ||
+      (0x2113 === codePoint) ||
+      (0x2116 === codePoint) ||
       (0x2121 <= codePoint && codePoint <= 0x2122) ||
-      (0x2126 == codePoint) ||
-      (0x212B == codePoint) ||
+      (0x2126 === codePoint) ||
+      (0x212B === codePoint) ||
       (0x2153 <= codePoint && codePoint <= 0x2154) ||
       (0x215B <= codePoint && codePoint <= 0x215E) ||
       (0x2160 <= codePoint && codePoint <= 0x216B) ||
       (0x2170 <= codePoint && codePoint <= 0x2179) ||
-      (0x2189 == codePoint) ||
+      (0x2189 === codePoint) ||
       (0x2190 <= codePoint && codePoint <= 0x2199) ||
       (0x21B8 <= codePoint && codePoint <= 0x21B9) ||
-      (0x21D2 == codePoint) ||
-      (0x21D4 == codePoint) ||
-      (0x21E7 == codePoint) ||
-      (0x2200 == codePoint) ||
+      (0x21D2 === codePoint) ||
+      (0x21D4 === codePoint) ||
+      (0x21E7 === codePoint) ||
+      (0x2200 === codePoint) ||
       (0x2202 <= codePoint && codePoint <= 0x2203) ||
       (0x2207 <= codePoint && codePoint <= 0x2208) ||
-      (0x220B == codePoint) ||
-      (0x220F == codePoint) ||
-      (0x2211 == codePoint) ||
-      (0x2215 == codePoint) ||
-      (0x221A == codePoint) ||
+      (0x220B === codePoint) ||
+      (0x220F === codePoint) ||
+      (0x2211 === codePoint) ||
+      (0x2215 === codePoint) ||
+      (0x221A === codePoint) ||
       (0x221D <= codePoint && codePoint <= 0x2220) ||
-      (0x2223 == codePoint) ||
-      (0x2225 == codePoint) ||
+      (0x2223 === codePoint) ||
+      (0x2225 === codePoint) ||
       (0x2227 <= codePoint && codePoint <= 0x222C) ||
-      (0x222E == codePoint) ||
+      (0x222E === codePoint) ||
       (0x2234 <= codePoint && codePoint <= 0x2237) ||
       (0x223C <= codePoint && codePoint <= 0x223D) ||
-      (0x2248 == codePoint) ||
-      (0x224C == codePoint) ||
-      (0x2252 == codePoint) ||
+      (0x2248 === codePoint) ||
+      (0x224C === codePoint) ||
+      (0x2252 === codePoint) ||
       (0x2260 <= codePoint && codePoint <= 0x2261) ||
       (0x2264 <= codePoint && codePoint <= 0x2267) ||
       (0x226A <= codePoint && codePoint <= 0x226B) ||
       (0x226E <= codePoint && codePoint <= 0x226F) ||
       (0x2282 <= codePoint && codePoint <= 0x2283) ||
       (0x2286 <= codePoint && codePoint <= 0x2287) ||
-      (0x2295 == codePoint) ||
-      (0x2299 == codePoint) ||
-      (0x22A5 == codePoint) ||
-      (0x22BF == codePoint) ||
-      (0x2312 == codePoint) ||
+      (0x2295 === codePoint) ||
+      (0x2299 === codePoint) ||
+      (0x22A5 === codePoint) ||
+      (0x22BF === codePoint) ||
+      (0x2312 === codePoint) ||
       (0x2460 <= codePoint && codePoint <= 0x24E9) ||
       (0x24EB <= codePoint && codePoint <= 0x254B) ||
       (0x2550 <= codePoint && codePoint <= 0x2573) ||
@@ -215,37 +215,37 @@ eaw.eastAsianWidth = function(character) {
       (0x25BC <= codePoint && codePoint <= 0x25BD) ||
       (0x25C0 <= codePoint && codePoint <= 0x25C1) ||
       (0x25C6 <= codePoint && codePoint <= 0x25C8) ||
-      (0x25CB == codePoint) ||
+      (0x25CB === codePoint) ||
       (0x25CE <= codePoint && codePoint <= 0x25D1) ||
       (0x25E2 <= codePoint && codePoint <= 0x25E5) ||
-      (0x25EF == codePoint) ||
+      (0x25EF === codePoint) ||
       (0x2605 <= codePoint && codePoint <= 0x2606) ||
-      (0x2609 == codePoint) ||
+      (0x2609 === codePoint) ||
       (0x260E <= codePoint && codePoint <= 0x260F) ||
       (0x2614 <= codePoint && codePoint <= 0x2615) ||
-      (0x261C == codePoint) ||
-      (0x261E == codePoint) ||
-      (0x2640 == codePoint) ||
-      (0x2642 == codePoint) ||
+      (0x261C === codePoint) ||
+      (0x261E === codePoint) ||
+      (0x2640 === codePoint) ||
+      (0x2642 === codePoint) ||
       (0x2660 <= codePoint && codePoint <= 0x2661) ||
       (0x2663 <= codePoint && codePoint <= 0x2665) ||
       (0x2667 <= codePoint && codePoint <= 0x266A) ||
       (0x266C <= codePoint && codePoint <= 0x266D) ||
-      (0x266F == codePoint) ||
+      (0x266F === codePoint) ||
       (0x269E <= codePoint && codePoint <= 0x269F) ||
       (0x26BE <= codePoint && codePoint <= 0x26BF) ||
       (0x26C4 <= codePoint && codePoint <= 0x26CD) ||
       (0x26CF <= codePoint && codePoint <= 0x26E1) ||
-      (0x26E3 == codePoint) ||
+      (0x26E3 === codePoint) ||
       (0x26E8 <= codePoint && codePoint <= 0x26FF) ||
-      (0x273D == codePoint) ||
-      (0x2757 == codePoint) ||
+      (0x273D === codePoint) ||
+      (0x2757 === codePoint) ||
       (0x2776 <= codePoint && codePoint <= 0x277F) ||
       (0x2B55 <= codePoint && codePoint <= 0x2B59) ||
       (0x3248 <= codePoint && codePoint <= 0x324F) ||
       (0xE000 <= codePoint && codePoint <= 0xF8FF) ||
       (0xFE00 <= codePoint && codePoint <= 0xFE0F) ||
-      (0xFFFD == codePoint) ||
+      (0xFFFD === codePoint) ||
       (0x1F100 <= codePoint && codePoint <= 0x1F10A) ||
       (0x1F110 <= codePoint && codePoint <= 0x1F12D) ||
       (0x1F130 <= codePoint && codePoint <= 0x1F169) ||
@@ -261,7 +261,7 @@ eaw.eastAsianWidth = function(character) {
 
 eaw.characterLength = function(character) {
   var code = this.eastAsianWidth(character);
-  if (code == 'F' || code == 'W' || code == 'A') {
+  if (code === 'F' || code === 'W' || code === 'A') {
     return 2;
   } else {
     return 1;
@@ -298,7 +298,7 @@ eaw.slice = function(text, start, end) {
   for (var i = 0; i < chars.length; i++) {
     var char = chars[i];
     var charLen = eaw.length(char);
-    if (eawLen >= start - (charLen == 2 ? 1 : 0)) {
+    if (eawLen >= start - (charLen === 2 ? 1 : 0)) {
         if (eawLen + charLen <= end) {
             result += char;
         } else {


### PR DESCRIPTION
This fixes:
- `textLen` is undeclared, making `slice()` not usable in strict mode. (fc88eed3b203d8a42fde13c7e5d257e6670bc263)
- Cannot input 0 to `start` and `end` for `slice()`. For `end`, 0 is interpreted as 1. (04d2156e473d2697def941a11e69a013fc7b0619)
- Use strict equals `===`. (85c460532192313920cdbab93430e17a2380781b)